### PR TITLE
03/10/2025 15:04:10 - revert tokio tracing appender (it has no option…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Logs
 logs
-*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "gtranslate-app"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1629,7 +1629,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -4821,18 +4820,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 1.0.69",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtranslate-app"
-version = "0.2.3"
+version = "0.2.4"
 description = "A Tauri App"
 authors = ["z3ntl3"]
 edition = "2021"
@@ -26,7 +26,6 @@ tauri-plugin-translator-bindings = { version = "0.1.0", path = "../plugins/tauri
 tokio = { version = "1.43.0", features = ["fs"] }
 thiserror = "2.0.12"
 tracing-subscriber = {version = "0.3.19", features = ["chrono", "json"] }
-tracing-appender = "0.2"
 tracing = "0.1"
 tauri-plugin-clipboard-manager = "2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,14 +20,7 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_positioner::init())
         .setup(|mut app| {
-            let log_file = app
-                .path()
-                .resolve("app.log", BaseDirectory::Resource)
-                .unwrap();
-            let tracing = tracing_appender::rolling::never(log_file, "app.log");
-
             tracing_subscriber::fmt()
-                .with_writer(tracing)
                 .with_max_level(LevelFilter::DEBUG)
                 .with_timer(ChronoLocal::new("%v - %H:%M:%S".to_owned()))
                 .with_file(true)
@@ -81,7 +74,6 @@ pub fn run() {
                     }
                 }
             });
-
 
             // build and configure system tray stuff in background
             #[cfg(desktop)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,6 @@
       "icons/glogo.ico"
     ],
     "resources": {
-      "../src/app.log": "app.log/app.log",
       "../src/assets/app-conf.json": "app-conf.json"
     }, 
     "createUpdaterArtifacts": true


### PR DESCRIPTION

#### Fixes
- On some Windows computers it might have required admin permissions to start
  > This is because some user specific settings might require the application with higher privileges to access folders within ``C:\``, even if the app tries to access resource files of it's own in only ``append`` mode. This is reverted, and tracing logs are written to stdout, they have to be tested and reproduced using ``cargo tauri build --debug``